### PR TITLE
Add export_tracing_func to _GlobalSw

### DIFF
--- a/stopwatch_global.py
+++ b/stopwatch_global.py
@@ -23,10 +23,12 @@ class _GlobalSw(object):
     """A global store for thread-local stopwatches. Helps with the common case where
     the caller only wants one stopwatch per thread.
     """
-    def __init__(self, time_func=None, export_aggregated_timers_func=None):
+    def __init__(self, time_func=None, export_aggregated_timers_func=None,
+                 export_tracing_func=None):
         self.threadlocal_sws = threading.local()
         self.time_func = time_func
         self.export_agg_timers_func = export_aggregated_timers_func
+        self.export_tracing_func = export_tracing_func
 
     def global_sw(self):
         """Returns the thread local stopwatch (creating if it doesn't exists)"""
@@ -34,6 +36,7 @@ class _GlobalSw(object):
             self.threadlocal_sws.sw = StopWatch(
                 export_aggregated_timers_func=self.export_agg_timers_func,
                 time_func=self.time_func,
+                export_tracing_func=self.export_tracing_func,
             )
         return self.threadlocal_sws.sw
 

--- a/test_stopwatch_global.py
+++ b/test_stopwatch_global.py
@@ -4,6 +4,8 @@ from __future__ import print_function
 
 import pytest
 
+from mock import Mock
+
 from stopwatch_global import (
     global_sw,
     global_sw_del,
@@ -11,19 +13,29 @@ from stopwatch_global import (
 )
 
 
-def tracing_function(reported_traces):
-    pass
-
-
 @pytest.fixture
-def global_sw_fixture(request, tracing_func=tracing_function):
-    global_sw_init(export_tracing_func=tracing_func)
+def global_sw_fixture(request):
     request.addfinalizer(global_sw_del)
 
 
 @pytest.mark.usefixtures('global_sw_fixture')
 class TestStopWatchGlobal(object):
+    @staticmethod
+    def add_spans():
+        with global_sw().timer('parent', start_time=20, end_time=80):
+            global_sw().add_span_annotation('parent_annotation', 1)
+            with global_sw().timer('child', start_time=40, end_time=40):
+                global_sw().add_span_annotation('child_annotation', 1)
+
+    def test_reported_traces(self):
+        tracing_function = Mock()
+        global_sw_init(export_tracing_func=tracing_function)
+        self.add_spans()
+        reported_traces = global_sw().get_last_trace_report()
+        tracing_function.assert_called_once_with(reported_traces=reported_traces)
+
     def test_global_sw(self):
+        global_sw_init()
         with global_sw().timer('root'):
             pass
         last_report = global_sw().get_last_aggregated_report()

--- a/test_stopwatch_global.py
+++ b/test_stopwatch_global.py
@@ -24,7 +24,7 @@ class TestStopWatchGlobal(object):
     def add_spans():
         with global_sw().timer('parent', start_time=20, end_time=80):
             global_sw().add_span_annotation('parent_annotation', 1)
-            with global_sw().timer('child', start_time=40, end_time=40):
+            with global_sw().timer('child', start_time=40, end_time=60):
                 global_sw().add_span_annotation('child_annotation', 1)
 
     def test_reported_traces(self):
@@ -32,6 +32,10 @@ class TestStopWatchGlobal(object):
         global_sw_init(export_tracing_func=tracing_function)
         self.add_spans()
         reported_traces = global_sw().get_last_trace_report()
+
+        assert len(reported_traces) == 2
+        assert reported_traces[0].trace_annotations[0].key == 'child_annotation'
+        assert reported_traces[1].trace_annotations[0].key == 'parent_annotation'
         tracing_function.assert_called_once_with(reported_traces=reported_traces)
 
     def test_global_sw(self):

--- a/test_stopwatch_global.py
+++ b/test_stopwatch_global.py
@@ -10,10 +10,16 @@ from stopwatch_global import (
     global_sw_init,
 )
 
+
+def tracing_function(reported_traces):
+    pass
+
+
 @pytest.fixture
-def global_sw_fixture(request):
-    global_sw_init()
+def global_sw_fixture(request, tracing_func=tracing_function):
+    global_sw_init(export_tracing_func=tracing_func)
     request.addfinalizer(global_sw_del)
+
 
 @pytest.mark.usefixtures('global_sw_fixture')
 class TestStopWatchGlobal(object):


### PR DESCRIPTION
`_GlobalSw` doesn't allow to set a `export_tracing_func` that contains the span annotations. Add a param to expose this functionality.