### PR TITLE
Add callback that takes in both agg_timers and reported_traces

### DIFF
--- a/stopwatch.py
+++ b/stopwatch.py
@@ -128,6 +128,10 @@ def default_export_aggregated_timers(aggregated_report):
     """Default implementation of aggregated timer logging"""
     pass
 
+def default_export_aggregated_timers_and_tracing(aggregated_report, reported_traces):
+    """Default implementation of aggregated timer logging and non-aggregated trace logging"""
+
+
 class StopWatch(object):
     """StopWatch - main class for storing timer stack and exposing timer functions/contextmanagers
     to the rest of the code"""
@@ -138,7 +142,8 @@ class StopWatch(object):
                  export_aggregated_timers_func=None,
                  max_tracing_spans_for_path=1000,
                  min_tracing_milliseconds=3,
-                 time_func=None):
+                 time_func=None,
+                 export_aggregated_timers_and_tracing_func=None):
         """
         Arguments:
           strict_assert: If True, assert on callsite misuse
@@ -158,6 +163,9 @@ class StopWatch(object):
 
           time_func:
             Function which returns the current time in seconds. Defaults to time.time
+
+          export_aggregated_timers_and_tracing_func:
+            Function to export log timers and log tracing data when stack empties
         """
 
         self._timer_stack = []
@@ -165,6 +173,10 @@ class StopWatch(object):
         self._export_tracing_func = export_tracing_func or default_export_tracing
         self._export_aggregated_timers_func = (
             export_aggregated_timers_func or default_export_aggregated_timers
+        )
+        self._export_aggregated_timers_and_tracing_func = (
+            export_aggregated_timers_and_tracing_func or
+            default_export_aggregated_timers_and_tracing
         )
         self._time_func = time_func or time.time
         self.MAX_REQUEST_TRACING_SPANS_FOR_PATH = max_tracing_spans_for_path
@@ -297,6 +309,8 @@ class StopWatch(object):
             # Hit callbacks
             self._export_tracing_func(reported_traces=self._reported_traces)
             self._export_aggregated_timers_func(aggregated_report=agg_report)
+            self._export_aggregated_timers_and_tracing_func(aggregated_report=agg_report,
+                                                            reported_traces=self._reported_traces)
 
             self._reset()  # Clear out stats to prevent duplicate reporting
 

--- a/stopwatch_global.py
+++ b/stopwatch_global.py
@@ -24,11 +24,12 @@ class _GlobalSw(object):
     the caller only wants one stopwatch per thread.
     """
     def __init__(self, time_func=None, export_aggregated_timers_func=None,
-                 export_tracing_func=None):
+                 export_tracing_func=None, export_aggregated_timers_and_tracing_func=None):
         self.threadlocal_sws = threading.local()
         self.time_func = time_func
         self.export_agg_timers_func = export_aggregated_timers_func
         self.export_tracing_func = export_tracing_func
+        self.export_agg_timers_and_tracing_func = export_aggregated_timers_and_tracing_func
 
     def global_sw(self):
         """Returns the thread local stopwatch (creating if it doesn't exists)"""
@@ -37,6 +38,7 @@ class _GlobalSw(object):
                 export_aggregated_timers_func=self.export_agg_timers_func,
                 time_func=self.time_func,
                 export_tracing_func=self.export_tracing_func,
+                export_aggregated_timers_and_tracing_func=self.export_agg_timers_and_tracing_func,
             )
         return self.threadlocal_sws.sw
 

--- a/test_stopwatch_global.py
+++ b/test_stopwatch_global.py
@@ -35,20 +35,20 @@ class TestStopWatchGlobal(object):
                 global_sw().add_span_annotation('child_annotation', 1)
 
     def test_callbacks(self):
-        tracing_function = Mock()
+        tracing_func = Mock()
         agg_timers_and_tracing_func = Mock()
-        global_sw_init(export_tracing_func=tracing_function,
+        global_sw_init(export_tracing_func=tracing_func,
                        export_aggregated_timers_and_tracing_func=agg_timers_and_tracing_func)
         self.add_spans()
         last_report = global_sw().get_last_aggregated_report()
         reported_traces = global_sw().get_last_trace_report()
 
-        assert last_report.aggregated_values.keys() == ['parent', 'parent#child']
+        assert sorted(last_report.aggregated_values.keys()) == ['parent', 'parent#child']
 
         assert len(reported_traces) == 2
         assert reported_traces[0].trace_annotations[0].key == 'child_annotation'
         assert reported_traces[1].trace_annotations[0].key == 'parent_annotation'
 
-        tracing_function.assert_called_once_with(reported_traces=reported_traces)
+        tracing_func.assert_called_once_with(reported_traces=reported_traces)
         agg_timers_and_tracing_func.assert_called_once_with(aggregated_report=last_report,
                                                             reported_traces=reported_traces)

--- a/test_stopwatch_global.py
+++ b/test_stopwatch_global.py
@@ -20,6 +20,13 @@ def global_sw_fixture(request):
 
 @pytest.mark.usefixtures('global_sw_fixture')
 class TestStopWatchGlobal(object):
+    def test_global_sw(self):
+        global_sw_init()
+        with global_sw().timer('root'):
+            pass
+        last_report = global_sw().get_last_aggregated_report()
+        assert list(last_report.aggregated_values.keys()) == ['root']
+
     @staticmethod
     def add_spans():
         with global_sw().timer('parent', start_time=20, end_time=80):
@@ -27,20 +34,21 @@ class TestStopWatchGlobal(object):
             with global_sw().timer('child', start_time=40, end_time=60):
                 global_sw().add_span_annotation('child_annotation', 1)
 
-    def test_reported_traces(self):
+    def test_callbacks(self):
         tracing_function = Mock()
-        global_sw_init(export_tracing_func=tracing_function)
+        agg_timers_and_tracing_func = Mock()
+        global_sw_init(export_tracing_func=tracing_function,
+                       export_aggregated_timers_and_tracing_func=agg_timers_and_tracing_func)
         self.add_spans()
+        last_report = global_sw().get_last_aggregated_report()
         reported_traces = global_sw().get_last_trace_report()
+
+        assert last_report.aggregated_values.keys() == ['parent', 'parent#child']
 
         assert len(reported_traces) == 2
         assert reported_traces[0].trace_annotations[0].key == 'child_annotation'
         assert reported_traces[1].trace_annotations[0].key == 'parent_annotation'
-        tracing_function.assert_called_once_with(reported_traces=reported_traces)
 
-    def test_global_sw(self):
-        global_sw_init()
-        with global_sw().timer('root'):
-            pass
-        last_report = global_sw().get_last_aggregated_report()
-        assert list(last_report.aggregated_values.keys()) == ['root']
+        tracing_function.assert_called_once_with(reported_traces=reported_traces)
+        agg_timers_and_tracing_func.assert_called_once_with(aggregated_report=last_report,
+                                                            reported_traces=reported_traces)


### PR DESCRIPTION
Add another callback function that can take both aggregated_timers and reported_traces
Update `test_stopwatch_global.py` test this piece of functionality